### PR TITLE
Can now click on move visual to move

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,9 @@ set(SOURCE_FILES src/main.cpp
         src/System.cpp
         src/System.h
         src/PromotionUI.cpp
-        src/PromotionUI.h)
+        src/PromotionUI.h
+        src/MoveVisual.cpp
+        src/MoveVisual.h)
 set(SFML_STATIC_LIBRARIES true)
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include "ChessBoard.h"
 #include "ChessPiece.h"
+#include "MoveVisual.h"
 #include "PromotionUI.h"
 #include "Pieces/Pawn.h"
 #include "State.h"
@@ -23,7 +24,8 @@ class GameState : public State{
 
     ChessBoard m_board;
     std::vector<std::shared_ptr<ChessPiece>> m_pieces;
-    std::vector<sf::CircleShape> m_legalMoveVisuals;
+    std::vector<MoveVisual> m_legalMoveVisuals;
+    std::shared_ptr<ChessPiece> p_dragPiece;
     std::shared_ptr<ChessPiece> p_activePiece;
     sf::Vector2f m_lastPieceCoords;
 
@@ -40,7 +42,7 @@ class GameState : public State{
 
     void DoTurn();
     void DragPiece(sf::Vector2i position);
-    bool CheckSpot(sf::Vector2f position);
+    bool CheckSpot(sf::Vector2i position);
     std::vector<sf::Vector2i> CullMoves();
     void GenerateMoveVisuals(std::vector<sf::Vector2i> legalMoves);
     void ConfirmPiece(sf::Vector2i boardCoords);

--- a/src/MoveVisual.cpp
+++ b/src/MoveVisual.cpp
@@ -1,0 +1,34 @@
+//
+// Created by hunde on 5/7/2024.
+//
+
+#include "MoveVisual.h"
+
+MoveVisual::MoveVisual(const sf::Vector2i& boardPos) : m_boardPosition(boardPos)
+{
+
+    m_moveVisual.setRadius(10);
+    m_moveVisual.setOrigin(m_moveVisual.getRadius(), m_moveVisual.getRadius());
+    m_moveVisual.setPosition(boardPos.x * System::TILE_SIZE + System::X_CENTER_OFFSET + System::TILE_SIZE/2, boardPos.y * System::TILE_SIZE + System::TILE_SIZE/2);
+    m_moveVisual.setFillColor(sf::Color(135,206,250, 200));
+
+    m_activationRect = sf::FloatRect(boardPos.x * System::TILE_SIZE + System::X_CENTER_OFFSET, boardPos.y * System::TILE_SIZE, System::TILE_SIZE, System::TILE_SIZE);
+
+
+}
+
+sf::Vector2i MoveVisual::GetBoardCoordinates()
+{
+    return m_boardPosition;
+}
+
+bool MoveVisual::IsOverlapping(const sf::Vector2i &mousePos)
+{
+    return m_activationRect.contains(sf::Vector2f(mousePos.x, mousePos.y));
+}
+
+
+void MoveVisual::draw(sf::RenderTarget &target, sf::RenderStates states) const
+{
+    target.draw(m_moveVisual);
+}

--- a/src/MoveVisual.h
+++ b/src/MoveVisual.h
@@ -1,0 +1,28 @@
+//
+// Created by hunde on 5/7/2024.
+//
+
+#ifndef MOVEVISUAL_H
+#define MOVEVISUAL_H
+
+#include <SFML/Graphics.hpp>
+#include "System.h"
+
+class MoveVisual : public sf::Drawable {
+
+    sf::Vector2i m_boardPosition;
+    sf::CircleShape m_moveVisual;
+    sf::FloatRect m_activationRect;
+
+public:
+    MoveVisual(const sf::Vector2i& boardPos);
+
+    sf::Vector2i GetBoardCoordinates();
+    bool IsOverlapping(const sf::Vector2i& mousePos);
+
+    void draw(sf::RenderTarget &target, sf::RenderStates states) const override;
+};
+
+
+
+#endif //MOVEVISUAL_H


### PR DESCRIPTION
Rather than being forced to click and drag a piece, the player can now click on the move visuals and the piece will snap to that move. 