### PR TITLE
Game Traversal

### DIFF
--- a/src/ChessPiece.h
+++ b/src/ChessPiece.h
@@ -7,6 +7,8 @@
 #include <SFML/System/Vector2.hpp>
 #include <vector>
 #include <algorithm>
+#include <memory>
+
 #include "ChessBoard.h"
 #include "System.h"
 
@@ -46,6 +48,8 @@ public:
 
     const sf::Vector2i& GetBoardCoordinates();
     PieceType GetPieceType();
+
+    virtual std::shared_ptr<ChessPiece> clone() = 0;
 
 };
 

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -19,11 +19,8 @@
 class GameState : public State{
 
     struct Move {
-        std::shared_ptr<ChessPiece> Piece;
         std::vector<std::shared_ptr<ChessPiece>> StartPieces;
         std::vector<std::shared_ptr<ChessPiece>> EndPieces;
-        sf::Vector2i PieceStart;
-        sf::Vector2i PieceEnd;
     };
 
     void Update() override;
@@ -35,9 +32,8 @@ class GameState : public State{
 
     ChessBoard m_board;
     std::vector<std::shared_ptr<ChessPiece>> m_pieces;
-    std::vector<Move> m_moves;
-    sf::Vector2i m_attemptedPosition;
     std::vector<std::shared_ptr<ChessPiece>> m_tempPieces;
+    std::vector<Move> m_moves;
     std::vector<MoveVisual> m_legalMoveVisuals;
     std::shared_ptr<ChessPiece> p_dragPiece;
     std::shared_ptr<ChessPiece> p_activePiece;
@@ -72,6 +68,7 @@ class GameState : public State{
     void CheckWinCondition();
     void Checkmate();
 
+    std::vector<std::shared_ptr<ChessPiece>> CopyPieces();
 public:
     GameState(StateMachine* p_sm, sf::RenderWindow* p_rw);
     ~GameState();

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -14,22 +14,37 @@
 #include "Pieces/Pawn.h"
 #include "State.h"
 
+
+
 class GameState : public State{
+
+    struct Move {
+        std::shared_ptr<ChessPiece> Piece;
+        std::vector<std::shared_ptr<ChessPiece>> StartPieces;
+        std::vector<std::shared_ptr<ChessPiece>> EndPieces;
+        sf::Vector2i PieceStart;
+        sf::Vector2i PieceEnd;
+    };
 
     void Update() override;
     void Render() override;
     void HandleEvents() override;
+    void HandleKeyboardInput(sf::Keyboard::Key key) override;
 
 
 
     ChessBoard m_board;
     std::vector<std::shared_ptr<ChessPiece>> m_pieces;
+    std::vector<Move> m_moves;
+    sf::Vector2i m_attemptedPosition;
+    std::vector<std::shared_ptr<ChessPiece>> m_tempPieces;
     std::vector<MoveVisual> m_legalMoveVisuals;
     std::shared_ptr<ChessPiece> p_dragPiece;
     std::shared_ptr<ChessPiece> p_activePiece;
     sf::Vector2f m_lastPieceCoords;
 
-
+    int m_moveCounter;
+    int m_currentMoveCounter;
     bool m_bIsWhitePromoting;
     bool m_bIsBlackPromoting;
     PromotionUI m_whitePromotion;
@@ -48,6 +63,7 @@ class GameState : public State{
     void ConfirmPiece(sf::Vector2i boardCoords);
     void CapturePiece(sf::Vector2i boordCoords);
     void DetermineCheckStatus(sf::Vector2i exceptionBoardCoords = sf::Vector2i(-1,-1));
+    void ForceMove(std::shared_ptr<ChessPiece> p_piece, sf::Vector2i position);
     void CalculateBoardMoves();
     void HandlePieceMovement();
 

--- a/src/Pieces/Bishop.cpp
+++ b/src/Pieces/Bishop.cpp
@@ -72,3 +72,8 @@ void Bishop::CalculatePossibleMoves(const Board &board)
 
 }
 
+std::shared_ptr<ChessPiece> Bishop::clone()
+{
+    return std::make_shared<Bishop>(*this);
+}
+

--- a/src/Pieces/Bishop.h
+++ b/src/Pieces/Bishop.h
@@ -16,7 +16,7 @@ public:
 
     void CalculatePossibleMoves(const Board &board) override;
 
-
+    std::shared_ptr<ChessPiece> clone() override;
 };
 
 

--- a/src/Pieces/King.cpp
+++ b/src/Pieces/King.cpp
@@ -79,4 +79,9 @@ bool King::CanCastle(const Board &board, bool rightCastling)
     return true;
 }
 
+std::shared_ptr<ChessPiece> King::clone()
+{
+    return std::make_shared<King>(*this);
+}
+
 

--- a/src/Pieces/King.h
+++ b/src/Pieces/King.h
@@ -21,6 +21,7 @@ public:
     int AttemptMove(ChessBoard &board, sf::Vector2i position) override;
     bool CanCastle(const Board &board, bool rightCastling);
 
+    std::shared_ptr<ChessPiece> clone() override;
 };
 
 

--- a/src/Pieces/Knight.cpp
+++ b/src/Pieces/Knight.cpp
@@ -29,4 +29,9 @@ void Knight::CalculatePossibleMoves(const Board &board)
     }
 }
 
+std::shared_ptr<ChessPiece> Knight::clone()
+{
+    return std::make_shared<Knight>(*this);
+}
+
 

--- a/src/Pieces/Knight.h
+++ b/src/Pieces/Knight.h
@@ -12,7 +12,7 @@ public:
     Knight(sf::Vector2i position, bool bIsBlack);
     void CalculatePossibleMoves(const Board &board) override;
 
-
+    std::shared_ptr<ChessPiece> clone() override;
 };
 
 

--- a/src/Pieces/Pawn.cpp
+++ b/src/Pieces/Pawn.cpp
@@ -40,6 +40,11 @@ void Pawn::CalculatePossibleMoves(const Board &board)
 
 }
 
+std::shared_ptr<ChessPiece> Pawn::clone()
+{
+    return std::make_shared<Pawn>(*this);
+}
+
 
 
 

--- a/src/Pieces/Pawn.h
+++ b/src/Pieces/Pawn.h
@@ -15,6 +15,7 @@ public:
     Pawn(sf::Vector2i position, bool bIsBlack);
     void CalculatePossibleMoves(const Board& board) override;
 
+    std::shared_ptr<ChessPiece> clone() override;
 };
 
 

--- a/src/Pieces/Queen.cpp
+++ b/src/Pieces/Queen.cpp
@@ -4,6 +4,8 @@
 
 #include "Queen.h"
 
+#include <memory>
+
 Queen::Queen(sf::Vector2i position, bool bIsBlack) : ChessPiece(position, bIsBlack)
 {
     m_pieceType = bIsBlack ? BLACK_QUEEN : WHITE_QUEEN;
@@ -125,5 +127,10 @@ void Queen::CalculatePossibleMoves(const Board &board)
         }else break;
     }
 
+}
+
+std::shared_ptr<ChessPiece> Queen::clone()
+{
+    return std::make_shared<Queen>(*this);
 }
 

--- a/src/Pieces/Queen.h
+++ b/src/Pieces/Queen.h
@@ -14,6 +14,7 @@ public:
 
     void CalculatePossibleMoves(const Board &board) override;
 
+    std::shared_ptr<ChessPiece> clone() override;
 };
 
 

--- a/src/Pieces/Rook.cpp
+++ b/src/Pieces/Rook.cpp
@@ -74,4 +74,9 @@ bool Rook::HasMoved()
     return m_bHasMoved;
 }
 
+std::shared_ptr<ChessPiece> Rook::clone()
+{
+    return std::make_shared<Rook>(*this);
+}
+
 

--- a/src/Pieces/Rook.h
+++ b/src/Pieces/Rook.h
@@ -18,7 +18,7 @@ public:
 
     bool HasMoved();
 
-
+    std::shared_ptr<ChessPiece> clone() override;
 };
 
 


### PR DESCRIPTION
The player can now use the arrow keys to step forward and backwards through the moves. To accomplish this I create copies of the piece vector before and after the move and store it in a structure. I have a vector of move structures which i access according to the action, setting the active piece pointer to the vector stored in the structure. This is not very efficient and creates many copies of the pieces vector leading to a memory allocation of ~22KB per move. This is not desirable but it will suffice as a long game will only require ~2MB of memory to capture a full game. I previously tried storing a pointer to the piece active during the move and its beginning and end coordinates, but this did not work because of how castling is programmed, leading to only the king moving when stepping back. In the future it would be best to do it in a way that does not create so many copies. 