### PR TITLE
Fixed piece bug, AttemptMove does not modify board

### DIFF
--- a/src/ChessPiece.cpp
+++ b/src/ChessPiece.cpp
@@ -28,8 +28,7 @@ void ChessPiece::SetOriginToCenterOfTexture()
 }
 
 
-//Tries to move the piece to the specified location. Note that this function does nct call CalculatePossibleMoves on success.
-//Will not set piece position automatically, but will modify the chessboard in place.
+//Returns the result that moving will give. Does not move the piece
 //returns 0 on illegal move
 //returns 1 on move to empty square
 //returns 2 on move to filled square
@@ -40,14 +39,20 @@ int ChessPiece::AttemptMove(ChessBoard& board, sf::Vector2i position)
     {
         result++;
         result += board.GetBoard()[position.y][position.x] != EMPTY;
-        board.ModifyBoard(position, m_pieceType);
-        board.ModifyBoard(m_position, EMPTY);
-        m_position = position;
+
         return result;
 
     }
 
     return result;
+}
+
+//Moves the piece. Does not check if the move is legal, use AttemptMove to see the result of a move before calling this function
+void ChessPiece::MovePiece(ChessBoard& board, sf::Vector2i position)
+{
+    board.ModifyBoard(position, m_pieceType);
+    board.ModifyBoard(m_position, EMPTY);
+    m_position = position;
 }
 
 void ChessPiece::SetPiece(sf::Vector2i position)

--- a/src/ChessPiece.cpp
+++ b/src/ChessPiece.cpp
@@ -28,8 +28,7 @@ void ChessPiece::SetOriginToCenterOfTexture()
 }
 
 
-//Tries to move the piece to the specified location. Note that this function does nct call CalculatePossibleMoves on success.
-//Will not set piece position automatically, but will modify the chessboard in place.
+//Returns the result that moving will give. Does not move the piece
 //returns 0 on illegal move
 //returns 1 on move to empty square
 //returns 2 on move to filled square
@@ -42,12 +41,20 @@ int ChessPiece::AttemptMove(ChessBoard& board, sf::Vector2i position)
         result += board.GetBoard()[position.y][position.x] != EMPTY;
         board.ModifyBoard(position, m_pieceType);
         board.ModifyBoard(m_position, EMPTY);
-        m_position = position;
+
         return result;
 
     }
 
     return result;
+}
+
+//Moves the piece. Does not check if the move is legal, use AttemptMove to see the result of a move before calling this function
+void ChessPiece::MovePiece(ChessBoard& board, sf::Vector2i position)
+{
+    board.ModifyBoard(position, m_pieceType);
+    board.ModifyBoard(m_position, EMPTY);
+    m_position = position;
 }
 
 void ChessPiece::SetPiece(sf::Vector2i position)

--- a/src/ChessPiece.h
+++ b/src/ChessPiece.h
@@ -31,6 +31,7 @@ public:
     void SetOriginToCenterOfTexture();
 
     virtual int AttemptMove(ChessBoard& board, sf::Vector2i position);
+    void MovePiece(ChessBoard& board, sf::Vector2i position);
     void SetPiece(sf::Vector2i position);
     void SetHasMoved();
     virtual void CalculatePossibleMoves(const Board& board) = 0;

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -344,10 +344,9 @@ std::vector<sf::Vector2i> GameState::CullMoves()
             {
                 if((m_bWhiteIsChecked && !m_bIsBlackTurn) || (m_bBlackIsChecked && m_bIsBlackTurn))
                 {
-                    revert(tempBoard, tempPos);
                     continue;
                 }
-                p_activePiece->AttemptMove(m_board, sf::Vector2i(p_activePiece->GetBoardCoordinates().x + kingMove/2, p_activePiece->GetBoardCoordinates().y));
+                p_activePiece->MovePiece(m_board, sf::Vector2i(p_activePiece->GetBoardCoordinates().x + kingMove/2, p_activePiece->GetBoardCoordinates().y));
                 CalculateBoardMoves();
                 DetermineCheckStatus();
                 if((m_bWhiteIsChecked && !m_bIsBlackTurn) || (m_bBlackIsChecked && m_bIsBlackTurn))
@@ -359,10 +358,12 @@ std::vector<sf::Vector2i> GameState::CullMoves()
         }
         if(p_activePiece->AttemptMove(m_board, move) == 2)
         {
+            p_activePiece->MovePiece(m_board, move);
             CalculateBoardMoves();
             DetermineCheckStatus(move);
         }else
         {
+            p_activePiece->MovePiece(m_board, move);
             CalculateBoardMoves();
             DetermineCheckStatus();
         }
@@ -373,8 +374,6 @@ std::vector<sf::Vector2i> GameState::CullMoves()
         revert(tempBoard, tempPos);
     }
     return culledMoves;
-
-
 }
 
 void GameState::GenerateMoveVisuals(std::vector<sf::Vector2i> legalMoves)
@@ -391,19 +390,15 @@ void GameState::GenerateMoveVisuals(std::vector<sf::Vector2i> legalMoves)
 
 void GameState::ConfirmPiece(sf::Vector2i boardCoords)
 {
-    m_moveCounter++;
-    m_currentMoveCounter++;
-    Move move;
-    move.StartPieces = m_tempPieces;
-    move.EndPieces = CopyPieces();
-    m_moves.emplace_back(move);
 
     p_activePiece->SetHasMoved();
+    p_activePiece->MovePiece(m_board, boardCoords);
     SyncVisualsWithBoard(); //TODO: Only move active piece and castling piece
+    m_lastPieceCoords = p_activePiece->getPosition();
     HandlePieceMovement();
     m_legalMoveVisuals.clear();
     m_bIsBlackTurn = !m_bIsBlackTurn;
-    CheckWinCondition();
+    //CheckWinCondition();
 
     if(ShouldPromote())
     {
@@ -417,6 +412,14 @@ void GameState::ConfirmPiece(sf::Vector2i boardCoords)
             m_whitePromotion.SetUIPosition(sf::Vector2f(p_activePiece->GetBoardCoordinates().x * System::TILE_SIZE + System::X_CENTER_OFFSET - System::TILE_SIZE/4, 0));
         }
     }
+
+
+    m_moveCounter++;
+    m_currentMoveCounter++;
+    Move move;
+    move.StartPieces = m_tempPieces;
+    move.EndPieces = CopyPieces();
+    m_moves.emplace_back(move);
 
 }
 

--- a/src/Pieces/King.cpp
+++ b/src/Pieces/King.cpp
@@ -48,15 +48,17 @@ int King::AttemptMove(ChessBoard &board, sf::Vector2i position)
     int result = ChessPiece::AttemptMove(board, position);
 
     //Castling
-    if(result == 1 && lastPosition.x + 2 == position.x)
+    if(result == 1)
     {
-        p_rightRook->AttemptMove(board, sf::Vector2i(position.x-1, position.y));
+        if(lastPosition.x + 2 == position.x)
+        {
+            p_rightRook->MovePiece(board, sf::Vector2i(position.x-1, position.y));
+        }
+        if(lastPosition.x - 2 == position.x)
+        {
+            p_leftRook->MovePiece(board, sf::Vector2i(position.x+1, position.y));
+        }
     }
-    if(result == 1 && lastPosition.x - 2 == position.x)
-    {
-        p_leftRook->AttemptMove(board, sf::Vector2i(position.x+1, position.y));
-    }
-
 
     return result;
 }
@@ -67,11 +69,17 @@ bool King::CanCastle(const Board &board, bool rightCastling)
     if(rightCastling && p_rightRook->HasMoved())return false;
     if(!rightCastling && p_leftRook->HasMoved())return false;
 
-    if(rightCastling && (board[m_position.y][m_position.x + 1] | board[m_position.y][m_position.x + 2]) != EMPTY)
+    try
     {
-        return false;
-    }
-    if(!rightCastling && (board[m_position.y][m_position.x - 1] | board[m_position.y][m_position.x - 2]) != EMPTY)
+        if(rightCastling && (board[m_position.y].at(m_position.x + 1) | board[m_position.y].at(m_position.x + 2)) != EMPTY)
+        {
+            return false;
+        }
+        if(!rightCastling && (board[m_position.y].at(m_position.x - 1) | board[m_position.y].at(m_position.x - 2)) != EMPTY)
+        {
+            return false;
+        }
+    }catch(std::exception& e)
     {
         return false;
     }


### PR DESCRIPTION
Fixed a bug where clicking off a piece after moving it would return it to its position before the move. Attempt move also now does not move the board. Modifying the board with this function made it necessary to revert the board more than necessary. It is now split into two functions: AttemptMove and MovePiece. 